### PR TITLE
Update version to 8.7.0

### DIFF
--- a/src/cloudscribe.Web.Localization/cloudscribe.Web.Localization.csproj
+++ b/src/cloudscribe.Web.Localization/cloudscribe.Web.Localization.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>more flexible localization for ASP.NET Core</Description>
-    <Version>8.6.0</Version>
+    <Version>8.7.0</Version>
     <TargetFramework>net8.0</TargetFramework>
     <Authors>Joe Audette</Authors>
     <PackageId>cloudscribe.Web.Localization</PackageId>

--- a/update_version.ps1
+++ b/update_version.ps1
@@ -16,9 +16,9 @@
 $directory = "src"
 
 # Define the old & new versions
-$oldVersion = '8\.5'   # slash needed !
-$newVersion = "8.6.0"
-$newWildcardVersion = "8.6.*"
+$oldVersion = '8\.6'   # slash needed !
+$newVersion = "8.7.0"
+$newWildcardVersion = "8.7.*"
 	
 
 # Get all .csproj files in the directory and subdirectories


### PR DESCRIPTION
## Summary
- Updated version from 8.6 to 8.7.0 in all project files
- Updated PowerShell version script with new version numbers
- Built successfully with no errors or warnings

## Files Affected
- `update_version.ps1` - Updated version variables (8.6 → 8.7.0)
- `src/cloudscribe.Web.Localization/cloudscribe.Web.Localization.csproj` - Updated package version

## Test plan
- [x] PowerShell version script executed successfully
- [x] Solution builds without errors (0 warnings, 0 errors)
- [x] All package references updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)